### PR TITLE
Fix uninitialised vars and threads being closed that don't exist

### DIFF
--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -132,6 +132,7 @@ sctp_init(void)
 	SCTP_BASE_VAR(first_time) = 0;
 	SCTP_BASE_VAR(sctp_pcb_initialized) = 0;
 #if defined(__Userspace__)
+	SCTP_BASE_VAR(userspace_route) = -1;
 #if !defined(THREAD_SUPPORT)
 	SCTP_BASE_VAR(recvmbuf4) = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
 	SCTP_BASE_VAR(to_fill4) = MAXLEN_MBUF_CHAIN;
@@ -146,11 +147,6 @@ sctp_init(void)
 	SCTP_BASE_VAR(icmp_recvmbuf6) = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
 	SCTP_BASE_VAR(icmp_to_fill6) = MAXLEN_MBUF_CHAIN;
 #else
-#if !defined(__Userspace_os_Windows)
-#if defined(INET) || defined(INET6)
-	SCTP_BASE_VAR(userspace_route) = -1;
-#endif
-#endif
 #ifdef INET
 	SCTP_BASE_VAR(userspace_rawsctp) = -1;
 	SCTP_BASE_VAR(userspace_udpsctp) = -1;

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -132,9 +132,6 @@ sctp_init(void)
 	SCTP_BASE_VAR(first_time) = 0;
 	SCTP_BASE_VAR(sctp_pcb_initialized) = 0;
 #if defined(__Userspace__)
-#if !defined(__Userspace_os_Windows) && (defined(INET) || defined(INET6))
-	SCTP_BASE_VAR(userspace_route) = -1;
-#endif
 #if !defined(THREAD_SUPPORT)
 	SCTP_BASE_VAR(recvmbuf4) = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
 	SCTP_BASE_VAR(to_fill4) = MAXLEN_MBUF_CHAIN;
@@ -148,7 +145,10 @@ sctp_init(void)
 	SCTP_BASE_VAR(icmp_to_fill4) = MAXLEN_MBUF_CHAIN;
 	SCTP_BASE_VAR(icmp_recvmbuf6) = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
 	SCTP_BASE_VAR(icmp_to_fill6) = MAXLEN_MBUF_CHAIN;
-#else
+#endif
+#if !defined(__Userspace_os_Windows) && (defined(INET) || defined(INET6))
+	SCTP_BASE_VAR(userspace_route) = -1;
+#endif
 #ifdef INET
 	SCTP_BASE_VAR(userspace_rawsctp) = -1;
 	SCTP_BASE_VAR(userspace_udpsctp) = -1;
@@ -158,7 +158,6 @@ sctp_init(void)
 	SCTP_BASE_VAR(userspace_rawsctp6) = -1;
 	SCTP_BASE_VAR(userspace_udpsctp6) = -1;
 	SCTP_BASE_VAR(userspace_icmp6) = -1;
-#endif
 #endif
 	SCTP_BASE_VAR(timer_thread_should_exit) = 0;
 	SCTP_BASE_VAR(conn_output) = conn_output;

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -132,7 +132,9 @@ sctp_init(void)
 	SCTP_BASE_VAR(first_time) = 0;
 	SCTP_BASE_VAR(sctp_pcb_initialized) = 0;
 #if defined(__Userspace__)
+#if !defined(__Userspace_os_Windows) && (defined(INET) || defined(INET6))
 	SCTP_BASE_VAR(userspace_route) = -1;
+#endif
 #if !defined(THREAD_SUPPORT)
 	SCTP_BASE_VAR(recvmbuf4) = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
 	SCTP_BASE_VAR(to_fill4) = MAXLEN_MBUF_CHAIN;

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -264,12 +264,14 @@ sctp_finish(void)
 #endif
 	}
 #endif
+#if defined(THREAD_SUPPORT)
 	SCTP_BASE_VAR(timer_thread_should_exit) = 1;
 #if defined(__Userspace_os_Windows)
 	WaitForSingleObject(SCTP_BASE_VAR(timer_thread), INFINITE);
 	CloseHandle(SCTP_BASE_VAR(timer_thread));
 #else
 	pthread_join(SCTP_BASE_VAR(timer_thread), NULL);
+#endif
 #endif
 #endif
 	sctp_pcb_finish();


### PR DESCRIPTION
As a result of the discussion in https://github.com/rawrtc/rawrtc/issues/3.