### PR TITLE
Fix early debug messages

### DIFF
--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -75,8 +75,7 @@ extern const struct sctp_ss_functions sctp_ss_functions[];
 void
 #if defined(__Userspace__)
 sctp_init(uint16_t port,
-          int (*conn_output)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df),
-          void (*debug_printf)(const char *format, ...))
+          int (*conn_output)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df))
 #elif defined(__APPLE__) && (!defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) &&!defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION))
 sctp_init(struct protosw *pp SCTP_UNUSED, struct domain *dp SCTP_UNUSED)
 #else
@@ -164,7 +163,6 @@ sctp_init(void)
 #endif
 	SCTP_BASE_VAR(timer_thread_should_exit) = 0;
 	SCTP_BASE_VAR(conn_output) = conn_output;
-	SCTP_BASE_VAR(debug_printf) = debug_printf;
 	SCTP_BASE_VAR(crc32c_offloaded) = 0;
 #endif
 	sctp_pcb_init();

--- a/usrsctplib/netinet/sctp_var.h
+++ b/usrsctplib/netinet/sctp_var.h
@@ -451,8 +451,7 @@ void sctp_drain(void);
 #endif
 #if defined(__Userspace__)
 void sctp_init(uint16_t,
-               int (*)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df),
-               void (*)(const char *, ...));
+               int (*)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df));
 void sctp_notify(struct sctp_inpcb *, struct sctp_tcb *, struct sctp_nets *,
                  uint8_t, uint8_t, uint16_t, uint16_t);
 #elif defined(__FreeBSD__) && __FreeBSD_version < 902000

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -82,6 +82,7 @@ usrsctp_init(uint16_t port,
              int (*conn_output)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df),
              void (*debug_printf)(const char *format, ...))
 {
+	SCTP_BASE_VAR(debug_printf) = debug_printf;
 #if defined(__Userspace_os_Windows)
 #if defined(INET) || defined(INET6)
 	WSADATA wsaData;
@@ -104,7 +105,7 @@ usrsctp_init(uint16_t port,
 	pthread_mutexattr_destroy(&mutex_attr);
 	pthread_cond_init(&accept_cond, NULL);
 #endif
-	sctp_init(port, conn_output, debug_printf);
+	sctp_init(port, conn_output);
 }
 
 


### PR DESCRIPTION
Currently all debug messages before setting `SCTP_BASE_VAR(debug_printf)` will not be printed. Furthermore, I'm not even sure if `SCTP_BASE_VAR(debug_printf)` is properly initialised for early calls to the `SCTP_PRINTF` macro.

With these changes it is definitely initialised and early `SCTP_PRINTF` calls should output the messages as expected. Please check if we need to include `sctp_os_userspace.h` in `user_socket.c` before merging this PR.